### PR TITLE
Fixed the default UIView color

### DIFF
--- a/ColorMaker_With_UISlider/ViewController.swift
+++ b/ColorMaker_With_UISlider/ViewController.swift
@@ -33,8 +33,8 @@ class ViewController: UIViewController {
         greenSlider.value = 0
         blueSlider.value = 0
         
-        // MARK: - call to set the color when view loads
-        chooseColor()
+        //MARK: - Set the UIView with default color
+        colorView.backgroundColor = UIColor(red: 255, green: 255, blue: 255, alpha: 1)
     }
 
     //MARK:- Function to set the color


### PR DESCRIPTION
Whene the app is loading, because the sliders are defaulting to 0, the view outline is not getting displayed. So made it default to display white color.
From then on, whenever user changes the slider, it calls the chooseColor function to change the display color.